### PR TITLE
added Lightbox comp for spotlighting images on detail pages

### DIFF
--- a/src/components/critters/CritterDetails.jsx
+++ b/src/components/critters/CritterDetails.jsx
@@ -2,8 +2,10 @@ import { fetchCritter } from "../../services/CritterServices";
 import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { Link } from "react-router-dom";
+import { Lightbox } from "../misc/Lightbox";
 
 export const CritterDetails = () => {
+  const [lightboxOpen, setLightboxOpen] = useState(false);
   const [chosenCritter, setChosenCritter] = useState({
     type: { id: 0, label: "" },
     plants: [],
@@ -19,15 +21,28 @@ export const CritterDetails = () => {
     fetchAndSetCritter();
   }, []);
 
+  const openLightbox = () => setLightboxOpen(true);
+  const closeLightbox = () => setLightboxOpen(false);
+
   const displayCritter = () => {
     if (chosenCritter) {
       return (
         <div className="card-container flex justify-center">
           <div className="image-card flex flex-col w-[35rem] items-center">
-            <img
-              src={`${chosenCritter.image}`}
-              className="critter-image border-double border-4 border-amber-900 rounded-xl w-[30rem]"
-            />
+            <button onClick={openLightbox}>
+              <img
+                src={chosenCritter.image}
+                className="critter-image border-double border-4 border-amber-900 rounded-xl w-[30rem] h-[30rem] object-cover"
+                alt="Critter Image"
+              />
+            </button>
+
+            {lightboxOpen && (
+              <Lightbox
+                imageUrl={chosenCritter.image}
+                onClose={closeLightbox}
+              />
+            )}
           </div>
           <div className="details-card flex flex-col items-center border-solid round-xl bg-amber-100 w-[40rem] h-[30rem] rounded-3xl">
             <div className="critter-name text-3xl underline m-4">

--- a/src/components/misc/Lightbox.css
+++ b/src/components/misc/Lightbox.css
@@ -1,0 +1,35 @@
+.lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.lightbox-content {
+  position: relative;
+  max-height: 93vh; /* Limiting height to 80% of the screen height */
+  max-width: 93vh; /* Enable scrolling if the content exceeds the height */
+}
+
+.lightbox-image {
+  max-width: 100%;
+  max-height: 100%;
+  border: 1px solid white;
+  border-radius: 10px;
+  box-shadow: rgb(249, 229, 149) 0 0 5px;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: -10px;
+  right: 10px;
+  font-size: 40px;
+  color: white;
+  cursor: pointer;
+}

--- a/src/components/misc/Lightbox.jsx
+++ b/src/components/misc/Lightbox.jsx
@@ -1,0 +1,24 @@
+import "./Lightbox.css";
+
+export const Lightbox = ({ imageUrl, onClose }) => {
+  const handleOverlayClick = (event) => {
+    // Check if the click occurred outside the lightbox content
+    if (event.target.classList.contains("lightbox-overlay")) {
+      onClose();
+    }
+  };
+  return (
+    <div className="lightbox-overlay" onClick={handleOverlayClick}>
+      <div className="lightbox-content">
+        <span className="lightbox-close" onClick={onClose}>
+          &times;
+        </span>
+        <img
+          src={imageUrl}
+          alt="Expanded Plant Image"
+          className="lightbox-image"
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/plants/Favorites.jsx
+++ b/src/components/plants/Favorites.jsx
@@ -60,7 +60,6 @@ export const Favorites = () => {
               </div>
             );
           })}
-          ;
         </div>
       );
     } else if (allFavorites && allFavorites.length && searchTerm) {

--- a/src/components/plants/PlantDetails.jsx
+++ b/src/components/plants/PlantDetails.jsx
@@ -5,12 +5,14 @@ import {
   deleteFavoriteById,
   fetchMyFavorites,
 } from "../../services/PlantServices";
+import { Lightbox } from "../misc/Lightbox";
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Link } from "react-router-dom";
 
 export const PlantDetails = ({ userId }) => {
   const navigate = useNavigate();
+  const [lightboxOpen, setLightboxOpen] = useState(false);
   const [favorites, setFavorites] = useState([]);
   const [foundFavorite, setFoundFavorite] = useState({});
   const [chosenPlant, setChosenPlant] = useState({
@@ -57,15 +59,25 @@ export const PlantDetails = ({ userId }) => {
     deleteFavoriteById(favoriteId).then(window.location.reload());
   };
 
+  const openLightbox = () => setLightboxOpen(true);
+  const closeLightbox = () => setLightboxOpen(false);
+
   const displayPlant = () => {
     if (chosenPlant) {
       return (
         <div className="card-container flex justify-center">
           <div className="image-card flex flex-col w-[35rem] items-center">
-            <img
-              src={`${chosenPlant.image}`}
-              className="plant-image border-double border-4 border-amber-900 rounded-xl w-[30rem]"
-            />
+            <button onClick={openLightbox}>
+              <img
+                src={chosenPlant.image}
+                className="plant-image border-double border-4 border-amber-900 rounded-xl w-[30rem] h-[30rem] object-cover"
+                alt="Plant Image"
+              />
+            </button>
+
+            {lightboxOpen && (
+              <Lightbox imageUrl={chosenPlant.image} onClose={closeLightbox} />
+            )}
           </div>
           <div className="details-card flex flex-col items-center border-solid round-xl bg-amber-100 w-[40rem] h-[30rem] rounded-3xl">
             <div className="plant-name text-3xl underline m-1">


### PR DESCRIPTION
## Overview:

- User can now click on an image on any Plant or Critter Details page and it will expand the image and darken the rest of the screen with an opacity overlay

## Testing:

- Start the server and start the client app
- Login to the app in the browser and navigate to any Details page
- Click on the image and verify it expands and darkens the screen around it
- Verify you can close the image window by clicking on the x in the corner or anywhere on the overlay outside of the image