### PR TITLE
Lh popover take two

### DIFF
--- a/src/components/critters/CritterDetails.jsx
+++ b/src/components/critters/CritterDetails.jsx
@@ -1,18 +1,12 @@
 import { fetchCritter, fetchAllCritters } from "../../services/CritterServices";
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Link } from "react-router-dom";
 import { Lightbox } from "../misc/Lightbox";
-import {
-  Popover,
-  PopoverHandler,
-  PopoverContent,
-} from "@material-tailwind/react";
+import { PlantPopover } from "../misc/PlantPopover";
 
 export const CritterDetails = () => {
   const navigate = useNavigate();
   const [lightboxOpen, setLightboxOpen] = useState(false);
-  const [popoverStates, setPopoverStates] = useState({});
   const [critters, setCritters] = useState([]);
   const [chosenCritter, setChosenCritter] = useState({
     type: { id: 0, label: "" },
@@ -78,16 +72,6 @@ export const CritterDetails = () => {
     }
   };
 
-  const handleMouseEnter = (plantId) => {
-    // Set the state for the corresponding plant to true
-    setPopoverStates((prevState) => ({ ...prevState, [plantId]: true }));
-  };
-
-  const handleMouseLeave = (plantId) => {
-    // Set the state for the corresponding plant to false
-    setPopoverStates((prevState) => ({ ...prevState, [plantId]: false }));
-  };
-
   const displayCritter = () => {
     if (chosenCritter) {
       return (
@@ -142,51 +126,9 @@ export const CritterDetails = () => {
                 {chosenCritter.plants.length === 0 ? (
                   <div className="italic text-center">All plants!</div>
                 ) : (
-                  chosenCritter.plants.map((plant) => {
-                    const isOpen = popoverStates[plant.id];
-                    return (
-                      <div key={plant.id} className="plant-popover-link">
-                        <Popover
-                          offset={7}
-                          open={isOpen}
-                          handler={() => handleMouseLeave(plant.id)}
-                          transitionDuration={0}
-                        >
-                          <PopoverHandler
-                            onMouseEnter={() => handleMouseEnter(plant.id)}
-                            onMouseLeave={() => handleMouseLeave(plant.id)}
-                          >
-                            <Link
-                              to={`/plants/${plant.id}`}
-                              className="plant-name hover:font-bold focus:outline-none"
-                            >
-                              {plant.name}
-                            </Link>
-                          </PopoverHandler>
-                          <PopoverContent>
-                            <div className="popover-card -m-2.5 flex">
-                              <div className="image-container w-[10rem] h-[10rem]">
-                                <img
-                                  src={plant.image}
-                                  alt={`${plant.name}`}
-                                  className="h-full w-full rounded-md object-cover"
-                                />
-                              </div>
-                              <div className="plant-details flex flex-col items-center justify-evenly">
-                                <div className="plant-name w-[10rem] px-1 text-3xl font-bold text-center text-gray-dark font-pixel">
-                                  {plant.name}
-                                </div>
-                                <div className="plant-type w-[8rem] text-2xl italic font-bold text-center text-gray-dark font-pixel">
-                                  {plant.annual ? "Annual" : "Perennial"}{" "}
-                                  {plant.type.label}
-                                </div>
-                              </div>
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    );
-                  })
+                  chosenCritter.plants.map((plant) => (
+                    <PlantPopover key={plant.id} plant={plant} />
+                  ))
                 )}
               </div>
             </div>

--- a/src/components/misc/CritterPopover.jsx
+++ b/src/components/misc/CritterPopover.jsx
@@ -30,8 +30,8 @@ export const CritterPopover = ({ critter }) => {
           className="popover-card -m-2.5 flex bg-white p-2 rounded-lg"
           style={{
             position: "absolute",
-            top: "-10.8rem", // Adjust this value to your preference
-            left: "50%", // Centered horizontally
+            top: "-10.8rem",
+            left: "50%",
             transform: "translateX(-50%)",
             zIndex: "999",
           }}

--- a/src/components/misc/CritterPopover.jsx
+++ b/src/components/misc/CritterPopover.jsx
@@ -13,16 +13,15 @@ export const CritterPopover = ({ critter }) => {
   };
 
   return (
-    <div
-      className="critter-popover-link relative"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <Link
-        to={`/critters/${critter.id}`}
-        className="critter-name hover:font-bold focus:outline-none"
-      >
-        {critter.name}
+    <div className="critter-popover-link relative">
+      <Link to={`/critters/${critter.id}`} className="focus:outline-none">
+        <span
+          className="plant-name hover:font-bold hover:text-[1.5rem] hover:text-cyan-900"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          {critter.name}
+        </span>
       </Link>
 
       {isPopoverVisible && (
@@ -30,7 +29,7 @@ export const CritterPopover = ({ critter }) => {
           className="popover-card -m-2.5 flex bg-white p-2 rounded-lg"
           style={{
             position: "absolute",
-            top: "-10.8rem",
+            top: "-10.7rem",
             left: "50%",
             transform: "translateX(-50%)",
             zIndex: "999",
@@ -51,6 +50,21 @@ export const CritterPopover = ({ critter }) => {
               {critter.type.label}
             </div>
           </div>
+          {/* <div
+            className="arrow"
+            style={{
+              position: "absolute",
+              top: "100%", // Adjusted top value
+              left: "50%",
+              transform: "translateX(-50%)",
+              width: "0",
+              height: "0",
+              borderTop: "10px solid white", // Flipped
+              borderLeft: "10px solid transparent",
+              borderRight: "10px solid transparent",
+              borderBottom: "10px solid transparent", // Flipped
+            }}
+          /> */}
         </div>
       )}
     </div>

--- a/src/components/misc/CritterPopover.jsx
+++ b/src/components/misc/CritterPopover.jsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+export const CritterPopover = ({ critter }) => {
+  const [isPopoverVisible, setPopoverVisible] = useState(false);
+
+  const handleMouseEnter = () => {
+    setPopoverVisible(true);
+  };
+
+  const handleMouseLeave = () => {
+    setPopoverVisible(false);
+  };
+
+  return (
+    <div
+      className="critter-popover-link relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Link
+        to={`/critters/${critter.id}`}
+        className="critter-name hover:font-bold focus:outline-none"
+      >
+        {critter.name}
+      </Link>
+
+      {isPopoverVisible && (
+        <div
+          className="popover-card -m-2.5 flex bg-white p-2 rounded-lg"
+          style={{
+            position: "absolute",
+            top: "-10.8rem", // Adjust this value to your preference
+            left: "50%", // Centered horizontally
+            transform: "translateX(-50%)",
+            zIndex: "999",
+          }}
+        >
+          <div className="image-container w-[10rem] h-[10rem]">
+            <img
+              src={critter.image}
+              alt={`${critter.name}`}
+              className="h-full w-full rounded-md object-cover"
+            />
+          </div>
+          <div className="critter-details flex flex-col items-center justify-evenly">
+            <div className="critter-name w-[10rem] px-1 text-3xl font-bold text-center text-gray-dark font-pixel">
+              {critter.name}
+            </div>
+            <div className="critter-type w-[8rem] text-2xl italic font-bold text-center text-gray-dark font-pixel">
+              {critter.type.label}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/misc/PlantPopover.jsx
+++ b/src/components/misc/PlantPopover.jsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+export const PlantPopover = ({ plant }) => {
+  const [isPopoverVisible, setPopoverVisible] = useState(false);
+
+  const handleMouseEnter = () => {
+    setPopoverVisible(true);
+  };
+
+  const handleMouseLeave = () => {
+    setPopoverVisible(false);
+  };
+
+  return (
+    <div
+      className="plant-popover-link relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Link
+        to={`/plants/${plant.id}`}
+        className="plant-name hover:font-bold focus:outline-none"
+      >
+        {plant.name}
+      </Link>
+
+      {isPopoverVisible && (
+        <div
+          className="popover-card -m-2.5 flex bg-white p-2 rounded-lg"
+          style={{
+            position: "absolute",
+            top: "-10.8rem", // Adjust this value to your preference
+            left: "50%", // Centered horizontally
+            transform: "translateX(-50%)",
+            zIndex: "999",
+          }}
+        >
+          <div className="image-container w-[10rem] h-[10rem]">
+            <img
+              src={`http://localhost:8000/${plant.image}`}
+              alt={`${plant.name}`}
+              className="h-full w-full rounded-md object-cover"
+            />
+          </div>
+          <div className="plant-details flex flex-col items-center justify-evenly">
+            <div className="plant-name w-[10rem] px-1 text-3xl font-bold text-center text-gray-dark font-pixel">
+              {plant.name}
+            </div>
+            <div className="plant-type w-[8rem] text-2xl italic font-bold text-center text-gray-dark font-pixel">
+              {plant.annual ? "Annual" : "Perennial"} {plant.type.label}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/misc/PlantPopover.jsx
+++ b/src/components/misc/PlantPopover.jsx
@@ -37,7 +37,7 @@ export const PlantPopover = ({ plant }) => {
         >
           <div className="image-container w-[10rem] h-[10rem]">
             <img
-              src={`http://localhost:8000/${plant.image}`}
+              src={plant.image}
               alt={`${plant.name}`}
               className="h-full w-full rounded-md object-cover"
             />

--- a/src/components/misc/PlantPopover.jsx
+++ b/src/components/misc/PlantPopover.jsx
@@ -13,16 +13,14 @@ export const PlantPopover = ({ plant }) => {
   };
 
   return (
-    <div
-      className="plant-popover-link relative"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
+    <div className="plant-popover-link relative">
       <Link
         to={`/plants/${plant.id}`}
         className="plant-name hover:font-bold focus:outline-none"
       >
-        {plant.name}
+        <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+          {plant.name}
+        </span>
       </Link>
 
       {isPopoverVisible && (
@@ -30,8 +28,8 @@ export const PlantPopover = ({ plant }) => {
           className="popover-card -m-2.5 flex bg-white p-2 rounded-lg"
           style={{
             position: "absolute",
-            top: "-10.8rem", // Adjust this value to your preference
-            left: "50%", // Centered horizontally
+            top: "-10.8rem",
+            left: "50%",
             transform: "translateX(-50%)",
             zIndex: "999",
           }}
@@ -51,6 +49,21 @@ export const PlantPopover = ({ plant }) => {
               {plant.annual ? "Annual" : "Perennial"} {plant.type.label}
             </div>
           </div>
+          <div
+            className="arrow"
+            style={{
+              position: "absolute",
+              top: "100%", // Adjusted top value
+              left: "50%",
+              transform: "translateX(-50%)",
+              width: "0",
+              height: "0",
+              borderTop: "10px solid white", // Flipped
+              borderLeft: "10px solid transparent",
+              borderRight: "10px solid transparent",
+              borderBottom: "10px solid transparent", // Flipped
+            }}
+          />
         </div>
       )}
     </div>

--- a/src/components/misc/PlantPopover.jsx
+++ b/src/components/misc/PlantPopover.jsx
@@ -14,11 +14,12 @@ export const PlantPopover = ({ plant }) => {
 
   return (
     <div className="plant-popover-link relative">
-      <Link
-        to={`/plants/${plant.id}`}
-        className="plant-name hover:font-bold focus:outline-none"
-      >
-        <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <Link to={`/plants/${plant.id}`} className="focus:outline-none">
+        <span
+          className="plant-name hover:font-bold hover:text-[1.5rem] hover:text-light-green-900"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
           {plant.name}
         </span>
       </Link>
@@ -28,7 +29,7 @@ export const PlantPopover = ({ plant }) => {
           className="popover-card -m-2.5 flex bg-white p-2 rounded-lg"
           style={{
             position: "absolute",
-            top: "-10.8rem",
+            top: "-10.7rem",
             left: "50%",
             transform: "translateX(-50%)",
             zIndex: "999",
@@ -49,7 +50,7 @@ export const PlantPopover = ({ plant }) => {
               {plant.annual ? "Annual" : "Perennial"} {plant.type.label}
             </div>
           </div>
-          <div
+          {/* <div
             className="arrow"
             style={{
               position: "absolute",
@@ -63,7 +64,7 @@ export const PlantPopover = ({ plant }) => {
               borderRight: "10px solid transparent",
               borderBottom: "10px solid transparent", // Flipped
             }}
-          />
+          /> */}
         </div>
       )}
     </div>

--- a/src/components/plants/PlantDetails.jsx
+++ b/src/components/plants/PlantDetails.jsx
@@ -9,17 +9,12 @@ import {
 import { Lightbox } from "../misc/Lightbox";
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Link } from "react-router-dom";
-import {
-  Popover,
-  PopoverHandler,
-  PopoverContent,
-} from "@material-tailwind/react";
+import { PlantPopover } from "../misc/PlantPopover";
+import { CritterPopover } from "../misc/CritterPopover";
 
 export const PlantDetails = ({ userId }) => {
   const navigate = useNavigate();
   const [lightboxOpen, setLightboxOpen] = useState(false);
-  const [popoverStates, setPopoverStates] = useState({});
   const [favorites, setFavorites] = useState([]);
   const [foundFavorite, setFoundFavorite] = useState({});
   const [plants, setPlants] = useState([]);
@@ -113,16 +108,6 @@ export const PlantDetails = ({ userId }) => {
     }
   };
 
-  const handleMouseEnter = (plantId) => {
-    // Set the state for the corresponding plant to true
-    setPopoverStates((prevState) => ({ ...prevState, [plantId]: true }));
-  };
-
-  const handleMouseLeave = (plantId) => {
-    // Set the state for the corresponding plant to false
-    setPopoverStates((prevState) => ({ ...prevState, [plantId]: false }));
-  };
-
   const displayPlant = () => {
     if (chosenPlant) {
       return (
@@ -208,99 +193,20 @@ export const PlantDetails = ({ userId }) => {
                   {chosenPlant.companions.length === 0 ? (
                     <div className="italic text-center">None to show</div>
                   ) : (
-                    chosenPlant.companions.map((plant) => {
-                      const isOpen = popoverStates[plant.id];
-                      return (
-                        <div key={plant.id} className="plant-popover-link">
-                          <Popover
-                            offset={7}
-                            open={isOpen}
-                            handler={() => handleMouseLeave(plant.id)}
-                            transitionDuration={0}
-                          >
-                            <PopoverHandler
-                              onMouseEnter={() => handleMouseEnter(plant.id)}
-                              onMouseLeave={() => handleMouseLeave(plant.id)}
-                            >
-                              <Link
-                                to={`/plants/${plant.id}`}
-                                className="plant-name hover:font-bold focus:outline-none"
-                              >
-                                {plant.name}
-                              </Link>
-                            </PopoverHandler>
-                            <PopoverContent>
-                              <div className="popover-card -m-2.5 flex">
-                                <div className="image-container w-[10rem] h-[10rem]">
-                                  <img
-                                    src={`http://localhost:8000/${plant.image}`}
-                                    alt={`${plant.name}`}
-                                    className="h-full w-full rounded-md object-cover"
-                                  />
-                                </div>
-                                <div className="plant-details flex flex-col items-center justify-evenly">
-                                  <div className="plant-name w-[10rem] px-1 text-3xl font-bold text-center text-gray-dark font-pixel">
-                                    {plant.name}
-                                  </div>
-                                  <div className="plant-type w-[8rem] text-2xl italic font-bold text-center text-gray-dark font-pixel">
-                                    {plant.annual ? "Annual" : "Perennial"}{" "}
-                                    {plant.type.label}
-                                  </div>
-                                </div>
-                              </div>
-                            </PopoverContent>
-                          </Popover>
-                        </div>
-                      );
-                    })
+                    chosenPlant.companions.map((plant) => (
+                      <PlantPopover key={plant.id} plant={plant} />
+                    ))
                   )}
                 </div>
                 <div className="plant-critters text-xl">
-                  Potential Critters: <br></br>
-                  {chosenPlant.critters.map((critter) => {
-                    const isOpen = popoverStates[critter.id];
-                    return (
-                      <div key={critter.id} className="critter-popover-link">
-                        <Popover
-                          offset={7}
-                          open={isOpen}
-                          handler={() => handleMouseLeave(critter.id)}
-                          transitionDuration={0}
-                        >
-                          <PopoverHandler
-                            onMouseEnter={() => handleMouseEnter(critter.id)}
-                            onMouseLeave={() => handleMouseLeave(critter.id)}
-                          >
-                            <Link
-                              to={`/critters/${critter.id}`}
-                              className="critter-name hover:font-bold focus:outline-none"
-                            >
-                              {critter.name}
-                            </Link>
-                          </PopoverHandler>
-                          <PopoverContent>
-                            <div className="popover-card -m-2.5 flex">
-                              <div className="image-container w-[10rem] h-[10rem]">
-                                <img
-                                  src={critter.image}
-                                  alt={`${critter.name}`}
-                                  className="h-full w-full rounded-md object-cover"
-                                />
-                              </div>
-                              <div className="critter-details flex flex-col items-center justify-evenly">
-                                <div className="critter-name w-[10rem] px-1 text-3xl font-bold text-center text-gray-dark font-pixel">
-                                  {critter.name}
-                                </div>
-                                <div className="critter-type w-[8rem] text-2xl italic font-bold text-center text-gray-dark font-pixel">
-                                  {critter.type.label}
-                                </div>
-                              </div>
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    );
-                  })}
+                  Potential Critters: <br />
+                  {chosenPlant.critters.length === 0 ? (
+                    <div className="italic text-center">None to show</div>
+                  ) : (
+                    chosenPlant.critters.map((critter) => (
+                      <CritterPopover key={critter.id} critter={critter} />
+                    ))
+                  )}
                 </div>
               </div>
               <div className="buttons-container w-[15rem] flex justify-evenly">

--- a/src/components/plants/PlantList.jsx
+++ b/src/components/plants/PlantList.jsx
@@ -111,7 +111,7 @@ export const PlantList = () => {
       <div className="title search-bar flex w-3/4 mb-6 relative">
         <div className="title text-2xl mx-auto font-bold">Browse Plants</div>
         <button
-          className="add-plant-button text-2xl text-light-green-800 absolute left-0 underline"
+          className="add-plant-button text-2xl text-light-green-900 absolute left-0 underline"
           onClick={() => {
             navigate("/plants/newplant");
           }}


### PR DESCRIPTION
## Overview:

- Refactored the Popover element, ditched Material Tailwind and made unique Popovers for Companion Plants and Critters
- Popover is also now instantaneous with no ease-in ease-out kind of transition

## Testing:

- Start server and client app
- Login to the app and navigate to any PlantDetails  or CritterDetails page
- Verify that hovering over a companion plant name or potential critter name generates a popover